### PR TITLE
Add Appveyor builds

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,11 +9,15 @@ Regal
 
 | https://github.com/p3/regal
 | `Downloads <https://bitbucket.org/nigels_com/regal/downloads>`_, `Issues <https://github.com/p3/regal/issues>`_, `Commits <https://github.com/p3/regal/commits/master>`_.
-| Status: |status|
+| Status: Linux |status-linux|, Windows |status-windows|
 
-.. |status| image:: https://travis-ci.org/nigels-com/regal.png?branch=master
+.. |status-linux| image:: https://travis-ci.org/nigels-com/regal.png?branch=master
    :target: https://travis-ci.org/nigels-com/regal
-   :alt: Build Status
+   :alt: Linux Build Status
+
+.. |status-windows| image:: https://img.shields.io/appveyor/ci/regal/regal.svg
+   :target: https://ci.appveyor.com/project/regal/regal/
+   :alt: Windows Build Status
 
 Recent News
 ===========

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,8 @@ build:
 
 after_build:
 - cmd: >-
+    cd build/win32/vs2010/Regal
+    dir
     set ARCHIVE=Regal_Windows_x86_Debug_%APPVEYOR_BUILD_VERSION%.7z
-    7z a %ARCHIVE% build/win32/vs2010/Regal/Debug/Win32
+    7z a %ARCHIVE% Debug/Win32
     appveyor PushArtifact %ARCHIVE%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+version: '{build}-{branch}'
+clone_depth: 100
+
+init:
+- ps: >-
+    $version = Get-Date -Format "yyyymmddHHmm"
+    Update-AppveyorBuild -Version "$version"
+
+build:
+  project: build/win32/vs2010/Regal/Regal.sln
+  verbosity: normal
+
+after_build:
+- cmd: >-
+    set ARCHIVE=Regal_Windows_x86_Debug_%APPVEYOR_BUILD_VERSION%.7z
+    7z a %ARCHIVE% build/win32/vs2010/Regal/Debug/Win32
+    appveyor PushArtifact %ARCHIVE%


### PR DESCRIPTION
This requires somebody from the project devs to create team account as described here https://www.appveyor.com/docs/team-setup for the builds to work on specified address. Then appveyor.yml can be better tuned to suit project needs.

The proof of concept is there - https://ci.appveyor.com/project/techtonik/regal/build/201619241119/artifacts